### PR TITLE
Refactor to transformer

### DIFF
--- a/src/fx.ts
+++ b/src/fx.ts
@@ -1,423 +1,585 @@
-import { Observable, EMPTY, of, merge, concat,
-    filter, skip, take, first, map, switchMap, tap, share, takeWhile, scan, mapTo,
-    isEmpty, takeUntil, exhaustMap, mergeMap
-  } from 'rxjs';
-  import { valuesBetween, pointsBetween, Point, vector, ORIGIN } from './geom';
-  import { Drawable, Traceable, GraphObject, CanvasEffect, GraphEngine, Contact } from './render';
-  
-  // const inputisNotNull = <T>(value: T | null): value is T => value !== null;
+import {
+  Observable,
+  EMPTY,
+  of,
+  merge,
+  concat,
+  filter,
+  skip,
+  take,
+  first,
+  map,
+  switchMap,
+  tap,
+  share,
+  takeWhile,
+  scan,
+  mapTo,
+  isEmpty,
+  takeUntil,
+  exhaustMap,
+  mergeMap,
+} from "rxjs";
+import {
+  valuesBetween,
+  pointsBetween,
+  Point,
+  vector,
+  ORIGIN,
+  Identity,
+} from "./geom";
+import {
+  Drawable,
+  Traceable,
+  GraphObject,
+  CanvasEffect,
+  GraphEngine,
+  Contact,
+} from "./render";
 
-  const radiansPerSecond = (speed: number) => (ms: number) => speed * ms / 1000;
-  const easyGoing = (alpha: number) => alpha === 0 ? 0 : 1 - Math.sin(2 * Math.PI * alpha) / (2 * Math.PI * alpha);
-  const easyGoing2 = (alpha: number) => alpha === 0 ? 0 : 1 - Math.sin(4 * Math.PI * alpha) / (4 * Math.PI * alpha);
-  
-  // Observable operators
-  
-  /**
-   * operator que dada una secuencia de puntos, devuelve los incrementos (vectores) entre ambos.
-   * El número de incrementos será una unidad inferior al número de los valores del source.
-   */
-  export const deltaPoint = () => (source: Observable<Point>) => source.pipe(
-    scan(({ delta: _, last }: { delta: Point; last: Point }, value: Point) => ({ delta: vector(last, value), last: value }),
-         { delta: ORIGIN, last: ORIGIN }),
+// const inputisNotNull = <T>(value: T | null): value is T => value !== null;
+
+const radiansPerSecond = (speed: number) => (ms: number) => (speed * ms) / 1000;
+const easyGoing = (alpha: number) =>
+  alpha === 0 ? 0 : 1 - Math.sin(2 * Math.PI * alpha) / (2 * Math.PI * alpha);
+const easyGoing2 = (alpha: number) =>
+  alpha === 0 ? 0 : 1 - Math.sin(4 * Math.PI * alpha) / (4 * Math.PI * alpha);
+
+// Observable operators
+
+/**
+ * operator que dada una secuencia de puntos, devuelve los incrementos (vectores) entre ambos.
+ * El número de incrementos será una unidad inferior al número de los valores del source.
+ */
+export const deltaPoint = () => (source: Observable<Point>) =>
+  source.pipe(
+    scan(
+      ({ delta: _, last }: { delta: Point; last: Point }, value: Point) => ({
+        delta: vector(last, value),
+        last: value,
+      }),
+      { delta: ORIGIN, last: ORIGIN }
+    ),
     skip(1),
-    map(st => st.delta)
+    map((st) => st.delta)
   );
-  
-  const deltaLast = () => (source: Observable<Point>) => source.pipe(
-    scan(({ delta: _, last }: { delta: Point; last: Point }, value: Point) => ({ delta: vector(last, value), last: value }),
-         { delta: ORIGIN, last: ORIGIN }),
+
+const deltaLast = () => (source: Observable<Point>) =>
+  source.pipe(
+    scan(
+      ({ delta: _, last }: { delta: Point; last: Point }, value: Point) => ({
+        delta: vector(last, value),
+        last: value,
+      }),
+      { delta: ORIGIN, last: ORIGIN }
+    ),
     skip(1)
   );
-  
-  /** operator que dado una secuencia de tiempos en ms, devuelve los incrementos de tiempos entre valores */
-  const deltaTime = (source: Observable<number>) => source.pipe(
-    scan(({ time, delta: _ }: {time: number; delta: number}, t: number) => ({time: t, delta: time === 0 ? 0 : t - time}),
-          { time: 0, delta: 0 }),
-    map(td => td.delta)
+
+/** operator que dado una secuencia de tiempos en ms, devuelve los incrementos de tiempos entre valores */
+const deltaTime = (source: Observable<number>) =>
+  source.pipe(
+    scan(
+      ({ time, delta: _ }: { time: number; delta: number }, t: number) => ({
+        time: t,
+        delta: time === 0 ? 0 : t - time,
+      }),
+      { time: 0, delta: 0 }
+    ),
+    map((td) => td.delta)
   );
-  
-  /** operator que dada una secuencia de tiempos en ms, devuelve los tiempos relativos al primer tiempo */
-  const elapsedTime = (source: Observable<number>) => source.pipe(
-    scan(({ time, delta: _ }: {time: number; delta: number}, t: number) => ({time: t, delta: time === 0 ? 0 : t - time}),
-          { time: 0, delta: 0 }),
-    map(td => td.delta),
-    scan((elapsed, delta) => elapsed + delta, 0),
+
+/** operator que dada una secuencia de tiempos en ms, devuelve los tiempos relativos al primer tiempo */
+const elapsedTime = (source: Observable<number>) =>
+  source.pipe(
+    scan(
+      ({ time, delta: _ }: { time: number; delta: number }, t: number) => ({
+        time: t,
+        delta: time === 0 ? 0 : t - time,
+      }),
+      { time: 0, delta: 0 }
+    ),
+    map((td) => td.delta),
+    scan((elapsed, delta) => elapsed + delta, 0)
   );
-  
-  /**
-   * operator que dada una secuencia de tiempos en ms, devuelve secuencia de valores
-   * entre 0 y 1 que comprende una duración dada.
-   */
-  const duration = (ms: number) => (source: Observable<number>) => concat(
+
+/**
+ * operator que dada una secuencia de tiempos en ms, devuelve secuencia de valores
+ * entre 0 y 1 que comprende una duración dada.
+ */
+const duration = (ms: number) => (source: Observable<number>) =>
+  concat(
     source.pipe(
-      map(time => time / ms),
-      takeWhile(alpha => alpha < 1)
+      map((time) => time / ms),
+      takeWhile((alpha) => alpha < 1)
     ),
     of(1)
   );
-  
-  /**
-   * Operador que dada una secuencia de tiempos en ms, realiza un movimiento PROGRESIVO entre dos puntos dados,
-   * con la duración indicada y si se indica, con efecto ease.
-   * FLUJO ENTRANTE: tiempos en ms.
-   * FLUJO SALIENTE: secuencia puntos entre los extremos dados
-   */
-  export const movement = (from: Point, to: Point, ms: number, ease: boolean) => (source: Observable<number>) => source.pipe(
-    /// Implementar esta lógica en operador moveTo(this.graphic, 500, true) params: Drawable, ms, ease.
-    elapsedTime,
-    duration(ms),
-    // tap(a => console.log(`alpha: ${a}`)),
-    map((alpha: number) => ease ? easyGoing(alpha) : alpha),
-    // tap(a => console.log(`alpha': ${a}`)),
-    map(pointsBetween(from, to))
-  );
-  
-  /**
-   * Operador generalizado que dada una secuencia de tiempos en ms, devuelve una progresión de valores entre 0 y 1,
-   * con la duración indicada y si se indica, con efecto ease.
-   * FLUJO ENTRANTE: tiempos en ms.
-   * FLUJO SALIENTE: secuencia de valores entre 0 y 1
-   *
-   * NOTA: Para el caso concreto de valores entre dos puntos dados, usar mejor el operador movement.
-   * Este operador es una generalización que conviene usar cuando se quieren realizar múltiples operaciones (transformaciones
-   * geométricas) progresivas simultáneamente (e.g. trasladar entre dos puntos y escalar).
-   */
-  export const span = (ms: number, ease = false) => (source: Observable<number>) => source.pipe(
-    elapsedTime,
-    duration(ms),
-    // tap(a => console.log(`alpha: ${a}`)),
-    map((alpha: number) => ease ? easyGoing(alpha) : alpha),
-    // tap(a => console.log(`alpha': ${a}`)),
-  );
-  
-  export const EMPTY_EFFECT: CanvasEffect = { target: null, pulse: () => EMPTY };
-  
-  /**
-   * Conmute effects every time a switch$ (e.g. click$, hold$, etc) event comes.
-   */
-  export class EffectSwitcher implements CanvasEffect {
-  
-    private next = 0;
-    private effects: CanvasEffect[];
-  
-    constructor(private engine: GraphEngine, private switch$: Observable<any>, public target: GraphObject,
-                private started: boolean, ...effects: CanvasEffect[]) {
-      this.effects = effects.length > 1 ? effects : [ ...effects, EMPTY_EFFECT];
-    }
-  
-    pulse(): Observable<any> {
-      const start = this.started ? of(null) : EMPTY; // check whether is initially started
-      return concat(
-        start,
-        this.switch$.pipe(
-          this.engine.pointer.filterPointWithContact(this.target),
-          map(({ point }) => point)
-        )
-      ).pipe(
-        switchMap(() => this.effects[this.next++ % this.effects.length].pulse())
-      );
-    }
+
+/**
+ * Operador que dada una secuencia de tiempos en ms, realiza un movimiento PROGRESIVO entre dos puntos dados,
+ * con la duración indicada y si se indica, con efecto ease.
+ * FLUJO ENTRANTE: tiempos en ms.
+ * FLUJO SALIENTE: secuencia puntos entre los extremos dados
+ */
+export const movement =
+  (from: Point, to: Point, ms: number, ease: boolean) =>
+  (source: Observable<number>) =>
+    source.pipe(
+      /// Implementar esta lógica en operador moveTo(this.graphic, 500, true) params: Drawable, ms, ease.
+      elapsedTime,
+      duration(ms),
+      // tap(a => console.log(`alpha: ${a}`)),
+      map((alpha: number) => (ease ? easyGoing(alpha) : alpha)),
+      // tap(a => console.log(`alpha': ${a}`)),
+      map(pointsBetween(from, to))
+    );
+
+/**
+ * Operador generalizado que dada una secuencia de tiempos en ms, devuelve una progresión de valores entre 0 y 1,
+ * con la duración indicada y si se indica, con efecto ease.
+ * FLUJO ENTRANTE: tiempos en ms.
+ * FLUJO SALIENTE: secuencia de valores entre 0 y 1
+ *
+ * NOTA: Para el caso concreto de valores entre dos puntos dados, usar mejor el operador movement.
+ * Este operador es una generalización que conviene usar cuando se quieren realizar múltiples operaciones (transformaciones
+ * geométricas) progresivas simultáneamente (e.g. trasladar entre dos puntos y escalar).
+ */
+export const span =
+  (ms: number, ease = false) =>
+  (source: Observable<number>) =>
+    source.pipe(
+      elapsedTime,
+      duration(ms),
+      // tap(a => console.log(`alpha: ${a}`)),
+      map((alpha: number) => (ease ? easyGoing(alpha) : alpha))
+      // tap(a => console.log(`alpha': ${a}`)),
+    );
+
+export const EMPTY_EFFECT: CanvasEffect = { target: null, pulse: () => EMPTY };
+
+/**
+ * Conmute effects every time a switch$ (e.g. click$, hold$, etc) event comes.
+ */
+export class EffectSwitcher implements CanvasEffect {
+  private next = 0;
+  private effects: CanvasEffect[];
+
+  constructor(
+    private engine: GraphEngine,
+    private switch$: Observable<any>,
+    public target: GraphObject,
+    private started: boolean,
+    ...effects: CanvasEffect[]
+  ) {
+    this.effects = effects.length > 1 ? effects : [...effects, EMPTY_EFFECT];
   }
-  
-  /// TODO Renombrar a DragLayerEffect?
-  export class TranslateLayerEffect implements CanvasEffect {
-  
-    public readonly target: Drawable | null= null;
-    public readonly pulse$: Observable<any>;
-  
-    constructor(engine: GraphEngine, layer: number, ...dependentLayers: number[]) {
-      this.pulse$ = engine.pointer.start$.pipe(
-        engine.pointer.filterPointWithoutContact(),
-        switchMap(_point => engine.pointer.move$.pipe(
+
+  pulse(): Observable<any> {
+    const start = this.started ? of(null) : EMPTY; // check whether is initially started
+    return concat(
+      start,
+      this.switch$.pipe(
+        this.engine.pointer.filterPointWithContact(this.target),
+        map(({ point }) => point)
+      )
+    ).pipe(
+      switchMap(() => this.effects[this.next++ % this.effects.length].pulse())
+    );
+  }
+}
+
+/// TODO Renombrar a DragLayerEffect?
+export class TranslateLayerEffect implements CanvasEffect {
+  public readonly target: Drawable | null = null;
+  public readonly pulse$: Observable<any>;
+
+  constructor(
+    engine: GraphEngine,
+    layer: number,
+    ...dependentLayers: number[]
+  ) {
+    this.pulse$ = engine.pointer.start$.pipe(
+      engine.pointer.filterPointWithoutContact(),
+      switchMap((_point) =>
+        engine.pointer.move$.pipe(
           takeUntil(engine.pointer.end$),
-          map(delta => engine.pointInLayer(delta, layer)),
+          map((delta) => engine.pointInLayer(delta, layer)),
           deltaPoint(),
           scan((acc, cur) => ({ x: acc.x + cur.x, y: acc.y + cur.y })), // take into account (conteract) own layer transformation
-          tap(delta => engine.translateLayers(delta, layer, ...dependentLayers)),
-        )),
-        share()
-      );
-    }
-  
-    pulse(): Observable<any> {
-      return this.pulse$;
-    }
+          tap((delta) => {
+            const t = Identity.translate(delta);
+            engine.transformLayer(layer, t);
+            for (const d of dependentLayers) {
+              engine.transformLayer(d, t);
+            }
+          })
+        )
+      ),
+      share()
+    );
   }
-  
-  export class ShiftLayerEffect implements CanvasEffect {
-  
-    public readonly target: Drawable | null = null;
-    public readonly pulse$: Observable<any>;
-    protected readonly delta$: Observable<{ delta: Point; last: Point }>;
-  
-    constructor(engine: GraphEngine, layer: number, horizontal: boolean, optionalStart$: Observable<Point> | null = null) {
-      const start$ = optionalStart$ ?? engine.pointer.start$.pipe(engine.pointer.filterPointWithoutContactAboveLayer(layer));
-      this.delta$ = start$.pipe(
-        switchMap(_point => engine.pointer.move$.pipe(
+
+  pulse(): Observable<any> {
+    return this.pulse$;
+  }
+}
+
+export class ShiftLayerEffect implements CanvasEffect {
+  public readonly target: Drawable | null = null;
+  public readonly pulse$: Observable<any>;
+  protected readonly delta$: Observable<{ delta: Point; last: Point }>;
+
+  constructor(
+    engine: GraphEngine,
+    layer: number,
+    horizontal: boolean,
+    optionalStart$: Observable<Point> | null = null
+  ) {
+    const start$ =
+      optionalStart$ ??
+      engine.pointer.start$.pipe(
+        engine.pointer.filterPointWithoutContactAboveLayer(layer)
+      );
+    this.delta$ = start$.pipe(
+      switchMap((_point) =>
+        engine.pointer.move$.pipe(
           takeUntil(engine.pointer.end$),
           deltaLast(),
-          map(({ delta, last }) => ({ delta: horizontal ? { x: delta.x, y: 0 } : { x: 0, y: delta.y }, last })),
-        )),
-      );
-      this.pulse$ = this.delta$.pipe(
-        tap(({ delta, last: _ }) => engine.translateLayer(delta, layer)),
-        share()
-      );
-    }
-  
-    pulse(): Observable<any> {
-      return this.pulse$;
-    }
+          map(({ delta, last }) => ({
+            delta: horizontal ? { x: delta.x, y: 0 } : { x: 0, y: delta.y },
+            last,
+          }))
+        )
+      )
+    );
+    this.pulse$ = this.delta$.pipe(
+      tap(({ delta, last: _ }) =>
+        engine.layerTransformer().translate(delta.x, delta.y)
+      ),
+      share()
+    );
   }
-  
-  export class FocusLayerEffect implements CanvasEffect {
-  
-    public readonly target: Drawable | null = null;
-    public readonly pulse$: Observable<any>;
-  
-    constructor(private engine: GraphEngine, private layer: number,
-                private focusPoint$: Observable<Point>) {
-      this.pulse$ = this.focusPoint$.pipe(
-        map(point => {
-          const [_a, _b, _c, _d, e, f] = this.engine.layerGeomCoefficients(this.layer);
-          return [{ x: e, y: f }, point] as [Point, Point];
-        }),
-        switchMap(([origin, dest]: [Point, Point]) => this.engine.frameOfLayer(layer).pipe(
+
+  pulse(): Observable<any> {
+    return this.pulse$;
+  }
+}
+
+export class FocusLayerEffect implements CanvasEffect {
+  public readonly target: Drawable | null = null;
+  public readonly pulse$: Observable<any>;
+
+  constructor(
+    private engine: GraphEngine,
+    private layer: number,
+    private focusPoint$: Observable<Point>
+  ) {
+    this.pulse$ = this.focusPoint$.pipe(
+      map((point) => {
+        const [_a, _b, _c, _d, e, f] = this.engine.layerGeomCoefficients(
+          this.layer
+        );
+        return [{ x: e, y: f }, point] as [Point, Point];
+      }),
+      switchMap(([origin, dest]: [Point, Point]) =>
+        this.engine.frameOfLayer(layer).pipe(
           movement(origin, dest, 500, true),
-          tap(point => {
-            const [a, b, c, d, _e, _f] = this.engine.layerGeomCoefficients(this.layer);
-            this.engine.setLayerGeomCoefficients(this.layer, [a, b, c, d, point.x, point.y]);
+          tap((point) => {
+            const [a, b, c, d, _e, _f] = this.engine.layerGeomCoefficients(
+              this.layer
+            );
+            this.engine.setLayerGeomCoefficients(this.layer, [
+              a,
+              b,
+              c,
+              d,
+              point.x,
+              point.y,
+            ]);
           })
-        )),
-        share()
-      );
-    }
-  
-    pulse(): Observable<any> {
-      return this.pulse$;
-    }
+        )
+      ),
+      share()
+    );
   }
-  
-  export class MoveGraphEffect implements CanvasEffect {
-  
-    public readonly target: Drawable | null = null;
-    public readonly pulse$: Observable<any>;
-  
-    constructor(engine: GraphEngine, graphMove$: Observable<{ graph: GraphObject; dest: Point }>, ms = 500, ease = true) {
-      this.pulse$ = graphMove$.pipe(
-        map(({ graph, dest }) => ({ graph, origin: graph.position, dest })),
-        mergeMap(({ graph, origin, dest }) => engine.frame(graph).pipe(
+
+  pulse(): Observable<any> {
+    return this.pulse$;
+  }
+}
+
+export class MoveGraphEffect implements CanvasEffect {
+  public readonly target: Drawable | null = null;
+  public readonly pulse$: Observable<any>;
+
+  constructor(
+    engine: GraphEngine,
+    graphMove$: Observable<{ graph: GraphObject; dest: Point }>,
+    ms = 500,
+    ease = true
+  ) {
+    this.pulse$ = graphMove$.pipe(
+      map(({ graph, dest }) => ({ graph, origin: graph.position, dest })),
+      mergeMap(({ graph, origin, dest }) =>
+        engine.frame(graph).pipe(
           movement(origin, dest, ms, ease),
-          tap(point => graph.position = point)
-        )),
-        share()
-      );
-    }
-  
-    pulse(): Observable<any> {
-      return this.pulse$;
-    }
+          tap((point) => (graph.position = point))
+        )
+      ),
+      share()
+    );
   }
-  
-  export interface Spinwise { spin: number }
-  
-  export class SpinEffect implements CanvasEffect {
-  
-    constructor(private frame$: Observable<number>, public target: Drawable & Spinwise, private clockwise = true) {}
-  
-    pulse(): Observable<any> {
-      return this.frame$.pipe(
-        deltaTime,
-        map(radiansPerSecond(Math.PI / 4)),
-        map(radians => this.clockwise ? radians : -radians),
-        tap(radians => this.target.spin += radians),
-        share()
-      );
-    }
+
+  pulse(): Observable<any> {
+    return this.pulse$;
   }
-  
-  export class QuarterTurnEffect implements CanvasEffect {
-  
-    constructor(private engine: GraphEngine, public target: GraphObject & Spinwise, private start$ = engine.pointer.start$) {}
-  
-    pulse(): Observable<any> {
-      return this.start$.pipe(
-        this.engine.pointer.filterPointWithContact(this.target),
-        map(({ point }) => point),
-        tap(() => this.engine.bringToTop(this.target)),
-        map(_point => this.target.spin),
-        exhaustMap(init => this.engine.frame(this.target).pipe( // exhaustMap para evitar más de un proceso a la vez
+}
+
+export interface Spinwise {
+  spin: number;
+}
+
+export class SpinEffect implements CanvasEffect {
+  constructor(
+    private frame$: Observable<number>,
+    public target: Drawable & Spinwise,
+    private clockwise = true
+  ) {}
+
+  pulse(): Observable<any> {
+    return this.frame$.pipe(
+      deltaTime,
+      map(radiansPerSecond(Math.PI / 4)),
+      map((radians) => (this.clockwise ? radians : -radians)),
+      tap((radians) => (this.target.spin += radians)),
+      share()
+    );
+  }
+}
+
+export class QuarterTurnEffect implements CanvasEffect {
+  constructor(
+    private engine: GraphEngine,
+    public target: GraphObject & Spinwise,
+    private start$ = engine.pointer.start$
+  ) {}
+
+  pulse(): Observable<any> {
+    return this.start$.pipe(
+      this.engine.pointer.filterPointWithContact(this.target),
+      map(({ point }) => point),
+      tap(() => this.engine.bringToTop(this.target)),
+      map((_point) => this.target.spin),
+      exhaustMap((init) =>
+        this.engine.frame(this.target).pipe(
+          // exhaustMap para evitar más de un proceso a la vez
           elapsedTime,
           duration(500),
           map(easyGoing2),
           map(valuesBetween(init, init + Math.PI / 2)),
-          tap(angle => this.target.spin = angle),
-        )),
-        share()
-      );
-    }
+          tap((angle) => (this.target.spin = angle))
+        )
+      ),
+      share()
+    );
   }
-  
-  export interface Elastic { elasticity: number }
-  
-  export class ElasticEffect implements CanvasEffect {
-  
-    constructor(private frame$: Observable<number>, public target: Drawable & Elastic) {}
-  
-    pulse(): Observable<any> {
-      return this.frame$.pipe(
-        map(radiansPerSecond(Math.PI / 4)),
-        map(radians => 1 + Math.cos(radians) / 2),
-        tap(elasticity => this.target.elasticity = elasticity),
-        share()
-      );
-    }
+}
+
+export interface Elastic {
+  elasticity: number;
+}
+
+export class ElasticEffect implements CanvasEffect {
+  constructor(
+    private frame$: Observable<number>,
+    public target: Drawable & Elastic
+  ) {}
+
+  pulse(): Observable<any> {
+    return this.frame$.pipe(
+      map(radiansPerSecond(Math.PI / 4)),
+      map((radians) => 1 + Math.cos(radians) / 2),
+      tap((elasticity) => (this.target.elasticity = elasticity)),
+      share()
+    );
   }
-  
-  export class PickUpEffect implements CanvasEffect {
-  
-    constructor(private engine: GraphEngine, public target: GraphObject & Elastic,
-                private start$: Observable<Point> = engine.pointer.start$) {}
-  
-    pulse(): Observable<any> {
-      const pickupPoint$ = this.start$.pipe(
-        this.engine.pointer.filterPointWithContact(this.target),
-        map(({ point }) => point)
-      );
-      const pickupEnd$ = pickupPoint$.pipe(
-        switchMap(_point => this.engine.pointer.end$.pipe(first()))
-      );
-      return merge(
-        // Fase crecimiento elasticidad (pick up)
-        pickupPoint$.pipe(
-          tap(() => this.engine.bringToTop(this.target)),
-          switchMap(_point => this.engine.frame(this.target).pipe(
+}
+
+export class PickUpEffect implements CanvasEffect {
+  constructor(
+    private engine: GraphEngine,
+    public target: GraphObject & Elastic,
+    private start$: Observable<Point> = engine.pointer.start$
+  ) {}
+
+  pulse(): Observable<any> {
+    const pickupPoint$ = this.start$.pipe(
+      this.engine.pointer.filterPointWithContact(this.target),
+      map(({ point }) => point)
+    );
+    const pickupEnd$ = pickupPoint$.pipe(
+      switchMap((_point) => this.engine.pointer.end$.pipe(first()))
+    );
+    return merge(
+      // Fase crecimiento elasticidad (pick up)
+      pickupPoint$.pipe(
+        tap(() => this.engine.bringToTop(this.target)),
+        switchMap((_point) =>
+          this.engine.frame(this.target).pipe(
             elapsedTime,
             duration(500),
             map(easyGoing2),
             map(valuesBetween(1, 1.5)),
-            tap(elasticity => this.target.elasticity = elasticity),
-            takeUntil(this.engine.pointer.end$),
-          ))
-        ),
-        // Fase retroceso elasticidad (drop down)
-        pickupEnd$.pipe(
-          // tap(() => console.log(`pickup end ${this.target.elasticity}`)),
-          map(_point => this.target.elasticity), // partimos de la elasticidad previa al end$
-          switchMap(max => this.engine.frame(this.target).pipe(
+            tap((elasticity) => (this.target.elasticity = elasticity)),
+            takeUntil(this.engine.pointer.end$)
+          )
+        )
+      ),
+      // Fase retroceso elasticidad (drop down)
+      pickupEnd$.pipe(
+        // tap(() => console.log(`pickup end ${this.target.elasticity}`)),
+        map((_point) => this.target.elasticity), // partimos de la elasticidad previa al end$
+        switchMap((max) =>
+          this.engine.frame(this.target).pipe(
             elapsedTime,
             duration(500),
             map(easyGoing2),
             map(valuesBetween(max, 1)),
-            tap(elasticity => this.target.elasticity = elasticity),
-        ))),
-      ).pipe(
-        share()
-      );
-    }
+            tap((elasticity) => (this.target.elasticity = elasticity))
+          )
+        )
+      )
+    ).pipe(share());
   }
-  
-  export class MovementEffect implements CanvasEffect {
-  
-    constructor(private engine: GraphEngine, public target: Drawable & Traceable,
-                private start$ = engine.pointer.start$) {}
-  
-    pulse(): Observable<any> {
-      const frame$ =this.engine.frame(this.target); /// ?? this.engine.frame$;
-      return this.start$.pipe(
-        this.engine.pointer.filterPointWithoutContact(),
-        map(point => this.engine.pointInGraphLayer(point, this.target)), // coord transformation
-        map(point => [this.target.position, point] as [Point, Point]),
-        switchMap(([origin, dest]: [Point, Point]) => frame$.pipe(
+}
+
+export class MovementEffect implements CanvasEffect {
+  constructor(
+    private engine: GraphEngine,
+    public target: Drawable & Traceable,
+    private start$ = engine.pointer.start$
+  ) {}
+
+  pulse(): Observable<any> {
+    const frame$ = this.engine.frame(this.target); /// ?? this.engine.frame$;
+    return this.start$.pipe(
+      this.engine.pointer.filterPointWithoutContact(),
+      map((point) => this.engine.pointInGraphLayer(point, this.target)), // coord transformation
+      map((point) => [this.target.position, point] as [Point, Point]),
+      switchMap(([origin, dest]: [Point, Point]) =>
+        frame$.pipe(
           movement(origin, dest, 500, true),
-          tap(point => this.target.position = point)
-        )),
-        share()
-      );
-    }
+          tap((point) => (this.target.position = point))
+        )
+      ),
+      share()
+    );
+  }
+}
+
+// const attrContactIsNotNull = (x: { origin: Point, contact: Contact | null, point: Point }): x is { origin: Point, contact: Contact, point: Point } => x.contact !== null;
+// const attrContactIsNotNull = <T extends { contact: Contact | null }>(x: T): x is T & { contact: Contact } => x.contact !== null;
+
+export class DragEffect implements CanvasEffect {
+  public readonly pulse$: Observable<any>;
+  public readonly drop$: Observable<{
+    origin: Point;
+    contact: Contact;
+    point: Point;
+  }>;
+  protected readonly drag$: Observable<{
+    origin: Point;
+    contact: Contact;
+    point: Point;
+  }>;
+
+  constructor(protected engine: GraphEngine, public target: GraphObject) {
+    this.drag$ = this.engine.pointer.drag$.pipe(
+      // filter(({ origin, contact, point }) => contact !== null && contact.graph === this.target),
+      // filter(attrContactIsNotNull), // filter(({ origin, contact, point }) => contact !== null),
+      filter(
+        <T extends { contact: Contact | null }>(
+          x: T
+        ): x is T & { contact: Contact } => x.contact !== null
+      ),
+      filter(
+        ({ origin: _origin, contact, point: _point }) =>
+          contact.graph === this.target
+      ),
+      map(({ origin, contact, point }) => ({
+        origin: this.engine.pointInGraphLayer(origin, this.target),
+        contact,
+        point: {
+          ...point,
+          ...this.engine.pointInGraphLayer(point, this.target),
+        },
+      }))
+    );
+    this.pulse$ = this.drag$.pipe(
+      map(({ contact, point }) => vector(contact.vector, point)),
+      tap((position) => (this.target.position = position)),
+      share()
+    );
+    this.drop$ = this.drag$.pipe(
+      switchMap((drag) => this.engine.pointer.end$.pipe(take(1), mapTo(drag)))
+    );
   }
 
-  // const attrContactIsNotNull = (x: { origin: Point, contact: Contact | null, point: Point }): x is { origin: Point, contact: Contact, point: Point } => x.contact !== null; 
-  // const attrContactIsNotNull = <T extends { contact: Contact | null }>(x: T): x is T & { contact: Contact } => x.contact !== null;
-  
-  export class DragEffect implements CanvasEffect {
-  
-    public readonly pulse$: Observable<any>;
-    public readonly drop$: Observable<{ origin: Point; contact: Contact; point: Point }>;
-    protected readonly drag$: Observable<{ origin: Point; contact: Contact; point: Point }>;
-  
-    constructor(protected engine: GraphEngine, public target: GraphObject) {
-      this.drag$ = this.engine.pointer.drag$.pipe(
-        // filter(({ origin, contact, point }) => contact !== null && contact.graph === this.target),
-        // filter(attrContactIsNotNull), // filter(({ origin, contact, point }) => contact !== null),
-        filter(<T extends { contact: Contact | null }>(x: T): x is T & { contact: Contact } => x.contact !== null),
-        filter(({ origin: _origin, contact, point: _point }) => contact.graph === this.target),
-        map(({ origin, contact, point }) => ({
-          origin: this.engine.pointInGraphLayer(origin, this.target),
-          contact,
-          point: { ...point, ...this.engine.pointInGraphLayer(point, this.target) }
-        }))
-      );
-      this.pulse$ = this.drag$.pipe(
-        map(({ contact, point }) => vector(contact.vector, point)),
-        tap(position => this.target.position = position),
-        share()
-      );
-      this.drop$ = this.drag$.pipe(
-        switchMap(drag => this.engine.pointer.end$.pipe(
-          take(1),
-          mapTo(drag)
-        ))
-      );
-    }
-  
-    pulse(): Observable<any> {
-      return this.pulse$;
-    }
+  pulse(): Observable<any> {
+    return this.pulse$;
   }
-  
-  export class DragAndComeBackEffect implements CanvasEffect {
-  
-    public readonly pulse$: Observable<any>;
-  
-    constructor(private engine: GraphEngine, public target: GraphObject) {
-      const dragEffect = new DragEffect(engine, target);
-      const dropWithContact$ = dragEffect.drop$.pipe(
-        switchMap(drop => this.engine.checkCollision(this.target).pipe(
+}
+
+export class DragAndComeBackEffect implements CanvasEffect {
+  public readonly pulse$: Observable<any>;
+
+  constructor(private engine: GraphEngine, public target: GraphObject) {
+    const dragEffect = new DragEffect(engine, target);
+    const dropWithContact$ = dragEffect.drop$.pipe(
+      switchMap((drop) =>
+        this.engine.checkCollision(this.target).pipe(
           isEmpty(),
-          filter(vacio => !vacio),
+          filter((vacio) => !vacio),
           mapTo(drop)
-        ))
-      );
-      const graphMove$ = dropWithContact$.pipe(
-        map(({ origin, contact, point: _ }) => ({ graph: target, dest: vector(contact.vector, origin) }))
-      );
-      const comeBackEffect = new MoveGraphEffect(engine, graphMove$);
-      this.pulse$ = merge(dragEffect.pulse$, comeBackEffect.pulse$);
-    }
-  
-    pulse(): Observable<any> {
-      return this.pulse$;
-    }
+        )
+      )
+    );
+    const graphMove$ = dropWithContact$.pipe(
+      map(({ origin, contact, point: _ }) => ({
+        graph: target,
+        dest: vector(contact.vector, origin),
+      }))
+    );
+    const comeBackEffect = new MoveGraphEffect(engine, graphMove$);
+    this.pulse$ = merge(dragEffect.pulse$, comeBackEffect.pulse$);
   }
-  
-  export interface Collidable { collision: boolean }
-  
-  export class CollisionEffect implements CanvasEffect {
-  
-    constructor(private collision$: Observable<[GraphObject, GraphObject]>,
-                public target: GraphObject & Collidable) {}
-  
-    pulse(): Observable<any> {
-      return this.collision$.pipe(
-        filter(([g1, g2]) => g1 === this.target || g2 === this.target),
-        tap(_ => this.target.collision = true),
-        share()
-      );
-    }
+
+  pulse(): Observable<any> {
+    return this.pulse$;
   }
-  
-  export const collisionEffect = (collision$: Observable<[GraphObject, GraphObject]>) =>
-                (graphic: GraphObject & Collidable) => new CollisionEffect(collision$, graphic);
-  
+}
+
+export interface Collidable {
+  collision: boolean;
+}
+
+export class CollisionEffect implements CanvasEffect {
+  constructor(
+    private collision$: Observable<[GraphObject, GraphObject]>,
+    public target: GraphObject & Collidable
+  ) {}
+
+  pulse(): Observable<any> {
+    return this.collision$.pipe(
+      filter(([g1, g2]) => g1 === this.target || g2 === this.target),
+      tap((_) => (this.target.collision = true)),
+      share()
+    );
+  }
+}
+
+export const collisionEffect =
+  (collision$: Observable<[GraphObject, GraphObject]>) =>
+  (graphic: GraphObject & Collidable) =>
+    new CollisionEffect(collision$, graphic);


### PR DESCRIPTION
The API to transform layers has methods for every kind of transformation:

* rotateLayer(), rotateLayers()
* scaleLayer(), scaleLayers()
* translateLayer(), translateLayers()

However there aren't those equivalent methods for graph transformations. Those could have been in the form of:

* rotateGraph()
* scaleGraph()
* translateGraph()

Instead, there only exists one:

* transformGraph()

Therefore it is required to unify both API at the time we define a new abstraction, the interface _Transformer_, to allow chaining transformations:

```typescript
interface Transformer {
  rotate(alpha: number): Transformer;
  scale(sx: number, sy: number): Transformer;
  translate(tx: number, ty: number): Transformer;
}
```

The new APIs in the _RenderManager_ class has two flavor of methods, to apply transformations using a single matrix or with the new chaining form using a Transformer.

_Matrix_ API:

* setTransformLayer(layer, matrix)
* transformLayer(layer, matrix)
* setTransformGraph(graph, matrix)
* transformGraph(graph, matrix)

> _setter_ methods replace existing matrix whereas non _setter_ methods are accumulatives on the existing matrix.

_Transformer_ API:

* layerTransformer(layer): Transformer
* graphTransformer(graph): Transformer

Below it is shown the same transformation on a _graph_ using both APIs:

_Matrix_ API:

```typescript
this.engine.transformGraph(graph,
  Identity.translate(px, py).rotate(alpha).translate(-px, -py)
);
```
_Transformer_ API:

```typescript
this.engine.graphTransformer(graph)
  .translate(-px, -py)
  .rotate(alpha)
  .translate(px, py);
```

Note the difference in the order of methods to apply the same transformation. _Transformer_ API is a way more intuitive: the methods are applied in the same order as they occur (_Matrix_ API is nearest to the mathematical matrix multiplication).


For simplicity sake it is removed old method that operate on multiple layers: e.g. `RenderManager.translateLayers()`.  
We can achieve the same result by applying the same transformation on different layers:

```typescript
const t = Identity.translate(px, py).rotate(alpha).translate(-px, -py);
this.engine.transformLayer(layer1, t);
this.engine.transformLayer(layer2, t);
```
